### PR TITLE
Hot config reloading

### DIFF
--- a/cmd/sql_exporter/main.go
+++ b/cmd/sql_exporter/main.go
@@ -61,6 +61,7 @@ func main() {
 	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) { http.Error(w, "OK", http.StatusOK) })
 	http.HandleFunc("/", HomeHandlerFunc(*metricsPath))
 	http.HandleFunc("/config", ConfigHandlerFunc(*metricsPath, exporter))
+	http.HandleFunc("/config/reload", ConfigReloadHandlerFunc(*metricsPath, exporter))
 	http.Handle(*metricsPath, ExporterHandlerFor(exporter))
 	// Expose exporter metrics separately, for debugging purposes.
 	http.Handle("/sql_exporter_metrics", promhttp.Handler())

--- a/examples/mysql/docker-compose.yml
+++ b/examples/mysql/docker-compose.yml
@@ -1,0 +1,32 @@
+# Please note all environment variables have default values defined in '.env' file
+# suitable for running acceptance tests in your local machine.
+version: '3.6'
+services:
+
+  mysql:
+    image: mysql/mysql-server:5.7
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_LOG_CONSOLE: "true"
+      MYSQL_ROOT_PASSWORD: sosecure
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "mysql", "-u", "root", "-psosecure"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  app:
+    image: sql_exporter:local
+    entrypoint: ["/bin/sql_exporter", "-config.file=/etc/sql_exporter/config.yml"]
+    ports:
+      - 9399:9399
+    environment:
+      EXPORTER_USERNAME: root
+      EXPORTER_PASSWORD: sosecure
+      EXPORTER_HOSTNAME: mysql
+    volumes:
+      # within `databases/alter/*.sql` there should
+      # be actual schema changes that differ from the initial seed
+      - ./files:/etc/sql_exporter

--- a/examples/mysql/files/config.yml
+++ b/examples/mysql/files/config.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_timeout_offset: 500ms
+  min_interval: 0s
+  max_connections: 3
+  max_idle_connections: 3
+target:
+  data_source_name: 'mysql://${EXPORTER_USERNAME}:${EXPORTER_PASSWORD}@tcp(${EXPORTER_HOSTNAME}:3306)/mysql'
+  collectors:
+    - mysql
+collector_files:
+  - "/etc/sql_exporter/*.collector.yml"

--- a/examples/mysql/files/mysql.collector.yml
+++ b/examples/mysql/files/mysql.collector.yml
@@ -1,0 +1,17 @@
+collector_name: mysql
+metrics:
+  - metric_name: sql_exporter_current_mysql_user_count
+    type: gauge
+    help: 'user count'
+    key_labels:
+      - user
+      - host
+    values:
+      - user_count
+    query: |
+        SELECT
+          user,
+          host,
+          1 AS user_count
+        FROM mysql.user
+        GROUP BY user, host;


### PR DESCRIPTION
This is useful on kubernetes set up as once ready we'll only be changing a config map which by default do not do not apply any strategy.

To fully accomplish the deployment definition must watch for those config map updates and query the exporter to reload its configuration